### PR TITLE
Update FragmentPresenterImpl.java

### DIFF
--- a/mvpro/src/main/java/org/loader/presenter/FragmentPresenterImpl.java
+++ b/mvpro/src/main/java/org/loader/presenter/FragmentPresenterImpl.java
@@ -34,6 +34,20 @@ public class FragmentPresenterImpl<T extends IView> extends Fragment implements 
             throw new RuntimeException(e.getMessage());
         }
     }
+    
+    @Override
+    public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
+        super.onViewStateRestored(savedInstanceState);
+        if (mView == null) {
+            try {
+                mView = getViewClass().newInstance();
+            } catch (java.lang.InstantiationException e) {
+                e.printStackTrace();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+    }
 
     @Override
     public Class<T> getViewClass() {


### PR DESCRIPTION
使用activity(fragment)作为presenter，当切换到后台时，activity被回收会造成持有的view层代理为空，如上添加可解决。